### PR TITLE
feat: add numpy to requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 h5py
 zarr
+numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 h5py
 zarr
+numpy


### PR DESCRIPTION
It gets pulled in by zarr and h5py but since it's explicitly used in the
code, nicer to have it explicitly listed too.